### PR TITLE
Fix pokedex switched lesser greater symbols

### DIFF
--- a/engine/pokedex/pokedex_evolution_page.asm
+++ b/engine/pokedex/pokedex_evolution_page.asm
@@ -432,7 +432,7 @@ EVO_stats:
 	cp ATK_EQ_DEF
 	jr z, .done
 	ld de, .atk_gt_def_text
-	cp ATK_LT_DEF
+	cp ATK_GT_DEF
 	jr z, .done
 	ld de, .atk_lt_def_text
 .done


### PR DESCRIPTION
Tyrogue's evo page should display correctly now:
ATK < DEF for Hitmonchan
ATK > DEF for Hitmonlee